### PR TITLE
Add optional example class

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -61,6 +61,7 @@ class KssBuilderTwig extends KssBuilderBaseTwig {
       showMarkup: true,
       markupClass: 'language-html',
       highlightSyntax: true,
+      exampleClass: '',
     });
   }
 }

--- a/index.twig
+++ b/index.twig
@@ -123,7 +123,7 @@
           <div class="kss-modifier__heading kss-style">
             {% if section.modifiers is not empty %}Default example{% else %}Example{% endif %}
           </div>
-          <div class="kss-modifier__example">
+          <div class="kss-modifier__example {{ options.exampleClass|default('') }}">
             {{ section.example|raw }}
           </div>
         </div>
@@ -133,7 +133,7 @@
             <div class="kss-modifier__heading kss-style">
               {{ modifier.description|raw }}
             </div>
-            <div class="kss-modifier__example">
+            <div class="kss-modifier__example {{ options.exampleClass|default('') }}">
               {{ modifier.markup|raw }}
             </div>
           </div>


### PR DESCRIPTION
Working with CSS frameworks (DTAs UI Kit specifically) sometimes namespace the body with a class that basic styles are connected to. 

This change allows us to set that class across all styleguide examples.